### PR TITLE
Allows Mac OS users to contribute without adding DS_store files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# OSX
+.DS_Store
+.DS_Store?


### PR DESCRIPTION
**GOAL**:
Allow Mac OS users to contribute to this project without accidentally adding `DS_store` files.

**CURRENT**:
Currently, your `.gitignore` is very comprehensive, but I couldn't help but notice that it excluded some `Mac OS` specific files. `Mac OS` users are fairly large portion of the `GH` open-source community and it would be great if they could contribute without adding unnecessary files.

**IMPACT:**
This will allow for a smoother dev experience for the`Mac OS` community.