### PR TITLE
README: Remove leading ellipsis from python examples in Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,22 +42,22 @@ Below is the packerlicious equivalent of `packer's example template`_
     >>> from packerlicious import builder, provisioner, Template
     >>> template = Template()
     >>> template.add_builder(
-    ...     builder.AmazonEbs(
-    ...         access_key="...",
-    ...         secret_key="...",
-    ...         region = "us-east-1",
-    ...         source_ami="ami-fce3c696",
-    ...         instance_type="t2.micro",
-    ...         ssh_username="ubuntu",
-    ...         ami_name="packer {{timestamp}}"
-    ...     )
-    ... )
+            builder.AmazonEbs(
+                access_key="...",
+                secret_key="...",
+                region = "us-east-1",
+                source_ami="ami-fce3c696",
+                instance_type="t2.micro",
+                ssh_username="ubuntu",
+                ami_name="packer {{timestamp}}"
+            )
+        )
     <packerlicious.builder.AmazonEbs object at 0x104e87ad0>
     >>> template.add_provisioner(
-    ...     provisioner.Shell(
-    ...         script="setup_things.sh"
-    ...     )
-    ... )
+            provisioner.Shell(
+                script="setup_things.sh"
+            )
+        )
     <packerlicious.provisioner.Shell object at 0x1048c08d0>
     >>> print(template.to_json())
     {


### PR DESCRIPTION
### Changes to Resolve Issue #28

#### Update Documentation
* Remove leading ellipsis from python examples in README.rst