### PR TITLE
default value to empty string for PYTHON in testenv:appveyor

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands=
     {envbindir}/coverage html -d {toxinidir}/htmlcov/{envname}
 
 [testenv:appveyor]
-basepython = {env:PYTHON}\python.exe
+basepython = {env:PYTHON:}\python.exe
 commands=
     {envbindir}/coverage run \
     -m pytest --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
Currently on Mac OSX Yosemite 10.10.5 and can't run tox locally
```bash
~/projects/packerlicious (master)$ tox
Traceback (most recent call last):
  File "/usr/local/bin/tox", line 11, in <module>
    sys.exit(cmdline())
  File "/Library/Python/2.7/site-packages/tox/session.py", line 38, in main
    config = prepare(args)
  File "/Library/Python/2.7/site-packages/tox/session.py", line 26, in prepare
    config = parseconfig(args)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 242, in parseconfig
    parseini(config, inipath)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 790, in __init__
    self.make_envconfig(name, section, reader._subs, config)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 821, in make_envconfig
    res = meth(env_attr.name, env_attr.default)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 1014, in getstring
    x = self._replace(x, name=name, crossonly=crossonly)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 1038, in _replace
    return Replacer(self, crossonly=crossonly).do_replace(value)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 1058, in do_replace
    return self.RE_ITEM_REF.sub(self._replace_match, x)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 1087, in _replace_match
    return self._replace_env(match)
  File "/Library/Python/2.7/site-packages/tox/config.py", line 1107, in _replace_env
    (envkey, envkey))
tox.ConfigError: ConfigError: substitution env:'PYTHON': unknown environment variable 'PYTHON'  or recursive definition.
```

The `PYTHON` environment variable is not set. Either it has to be setup manually or it could be defaulted in the tox settings to empty string. [environment-variable-substitutions](https://tox.readthedocs.io/en/latest/config.html#environment-variable-substitutions)
```bash
mprince ~/projects/packerlicious (master)$ tox
py26 develop-inst-nodeps: /Users/mprince/projects/packerlicious
py26 installed: DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6,argparse==1.4.0,coverage==4.4.1,future==0.16.0,importlib==1.0.4,ordereddict==1.1,-e git+git@github.com:mprince/packerlicious.git@75cb7db047307611b64a2e27acd33e022238918d#egg=packerlicious,py==1.4.34,pytest==3.2.1
py26 runtests: PYTHONHASHSEED='3695971766'
py26 runtests: commands[0] | find . -type f -name *.pyc -delete
py26 runtests: commands[1] | find . -type d -name __pycache__ -delete
py26 runtests: commands[2] | /Users/mprince/projects/packerlicious/.tox/py26/bin/coverage erase
py26 runtests: commands[3] | /Users/mprince/projects/packerlicious/.tox/py26/bin/coverage run /Users/mprince/projects/packerlicious/.tox/py26/bin/pytest --basetemp=/Users/mprince/projects/packerlicious/.tox/py26/tmp
============================================================ test session starts ============================================================
platform darwin -- Python 2.6.9, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /Users/mprince/projects/packerlicious/.tox/py26/bin/python2.6
cachedir: .cache
rootdir: /Users/mprince/projects/packerlicious, inifile: setup.cfg
collected 107 items
...
```