### PR TITLE
Added license and version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,13 @@ setup(
     install_requires=[
         "future",
     ],
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License'
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
## Issue Addressed
#55 

## Description
Added classifiers to `setup.py` for the project license and for the supported Python version.

If this isn't what you had in mind, let me know.
