### PR TITLE
add vsphere template post-processor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,7 @@ Post Processors:
 - vagrant
 - vagrant-cloud
 - vsphere
+- vsphere-template
 
 Provisioners:
 

--- a/src/packerlicious/post_processor.py
+++ b/src/packerlicious/post_processor.py
@@ -377,3 +377,20 @@ class VSphere(PackerPostProcessor):
         'options': ([str], False),
     }
 
+class VSphereTemplate(PackerPostProcessor):
+    """
+    vSphere Template Post-Processor
+    https://www.packer.io/docs/post-processors/vsphere-template.html
+    """
+
+    resource_type = "vsphere-template"
+
+    props = {
+        'host': (str, True),
+        'password': (str, True),
+        'username': (str, True),
+        'datacenter': (str, False),
+        'folder': (str, False),
+        'insecure': (validator.boolean, False),
+    }
+

--- a/tests/packerlicious/test_post_processor_vsphere_template.py
+++ b/tests/packerlicious/test_post_processor_vsphere_template.py
@@ -1,0 +1,13 @@
+import pytest
+
+import packerlicious.post_processor as post_processor
+
+
+class TestVSphereTemplateProcessor(object):
+
+    def test_required_fields_missing(self):
+        b = post_processor.VSphereTemplate()
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'required' in str(excinfo.value)


### PR DESCRIPTION
## Issue Addressed
#25 

## Description
add vsphere template post-processor

## List of Changes Proposed
add vsphere template post-processor

## Testing
tox output for one test added.
```bash
~/projects/packerlicious (issue25)$ tox -- tests/packerlicious/test_post_processor_vsphere_template.py 
py26 develop-inst-nodeps: /Users/mprince/projects/packerlicious
py26 installed: DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6,argparse==1.4.0,coverage==4.4.1,future==0.16.0,importlib==1.0.4,ordereddict==1.1,-e git+git@github.com:mprince/packerlicious.git@8b2a45aa3469db134adacce9f9b22fb22cfe5aa1#egg=packerlicious,py==1.4.34,pytest==3.2.1
py26 runtests: PYTHONHASHSEED='2107949572'
py26 runtests: commands[0] | find . -type f -name *.pyc -delete
py26 runtests: commands[1] | find . -type d -name __pycache__ -delete
py26 runtests: commands[2] | /Users/mprince/projects/packerlicious/.tox/py26/bin/coverage erase
py26 runtests: commands[3] | /Users/mprince/projects/packerlicious/.tox/py26/bin/coverage run /Users/mprince/projects/packerlicious/.tox/py26/bin/pytest --basetemp=/Users/mprince/projects/packerlicious/.tox/py26/tmp tests/packerlicious/test_post_processor_vsphere_template.py
============================================================ test session starts ============================================================
platform darwin -- Python 2.6.9, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /Users/mprince/projects/packerlicious/.tox/py26/bin/python2.6
cachedir: .cache
rootdir: /Users/mprince/projects/packerlicious, inifile: setup.cfg
collected 1 item                                                                                                                             

tests/packerlicious/test_post_processor_vsphere_template.py::TestVSphereTemplateProcessor::test_required_fields_missing PASSED

========================================================= 1 passed in 1.05 seconds ==========================================================
py26 runtests: commands[4] | /Users/mprince/projects/packerlicious/.tox/py26/bin/coverage html -d /Users/mprince/projects/packerlicious/htmlcov/py26
py27 develop-inst-nodeps: /Users/mprince/projects/packerlicious
py27 installed: coverage==4.4.1,future==0.16.0,-e git+git@github.com:mprince/packerlicious.git@8b2a45aa3469db134adacce9f9b22fb22cfe5aa1#egg=packerlicious,py==1.4.34,pytest==3.2.1
py27 runtests: PYTHONHASHSEED='2107949572'
py27 runtests: commands[0] | find . -type f -name *.pyc -delete
py27 runtests: commands[1] | find . -type d -name __pycache__ -delete
py27 runtests: commands[2] | /Users/mprince/projects/packerlicious/.tox/py27/bin/coverage erase
py27 runtests: commands[3] | /Users/mprince/projects/packerlicious/.tox/py27/bin/coverage run /Users/mprince/projects/packerlicious/.tox/py27/bin/pytest --basetemp=/Users/mprince/projects/packerlicious/.tox/py27/tmp tests/packerlicious/test_post_processor_vsphere_template.py
============================================================ test session starts ============================================================
platform darwin -- Python 2.7.10, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /Users/mprince/projects/packerlicious/.tox/py27/bin/python
cachedir: .cache
rootdir: /Users/mprince/projects/packerlicious, inifile: setup.cfg
collected 1 item                                                                                                                             

tests/packerlicious/test_post_processor_vsphere_template.py::TestVSphereTemplateProcessor::test_required_fields_missing PASSED

========================================================= 1 passed in 0.27 seconds ==========================================================
py27 runtests: commands[4] | /Users/mprince/projects/packerlicious/.tox/py27/bin/coverage html -d /Users/mprince/projects/packerlicious/htmlcov/py27
py33 create: /Users/mprince/projects/packerlicious/.tox/py33
ERROR: InterpreterNotFound: python3.3
py34 create: /Users/mprince/projects/packerlicious/.tox/py34
ERROR: InterpreterNotFound: python3.4
py35 create: /Users/mprince/projects/packerlicious/.tox/py35
ERROR: InterpreterNotFound: python3.5
py36 create: /Users/mprince/projects/packerlicious/.tox/py36
ERROR: InterpreterNotFound: python3.6
__________________________________________________________________ summary __________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
SKIPPED:  py33: InterpreterNotFound: python3.3
SKIPPED:  py34: InterpreterNotFound: python3.4
SKIPPED:  py35: InterpreterNotFound: python3.5
SKIPPED:  py36: InterpreterNotFound: python3.6
  congratulations :)
```
