### PR TITLE
Add guest_os_type options for puppet provisioner

### DIFF
--- a/src/packerlicious/provisioner.py
+++ b/src/packerlicious/provisioner.py
@@ -18,6 +18,9 @@ import warnings
 
 from . import BasePackerObject, PackerProperty, EnvVar, TemplateVar, validator
 
+# guest_os_type options for Chef and Puppet
+UNIX = "unix"
+WINDOWS = "windows"
 
 class PackerProvisioner(BasePackerObject):
 
@@ -81,10 +84,6 @@ class ChefClient(PackerProvisioner):
     """
     resource_type = "chef-client"
 
-    # guest_os_type options
-    UNIX = "unix"
-    WINDOWS = "windows"
-
     props = {
         'chef_environment': (str, False),
         'config_template': (str, False),
@@ -114,10 +113,6 @@ class ChefSolo(PackerProvisioner):
     https://www.packer.io/docs/provisioners/chef-solo.html
     """
     resource_type = "chef-solo"
-
-    # guest_os_type options
-    UNIX = "unix"
-    WINDOWS = "windows"
 
     props = {
         'chef_environment': (str, False),
@@ -246,8 +241,9 @@ class PuppetMasterless(PackerProvisioner):
 
     props = {
         'manifest_file': (str, True),
-        'extra_arguments': ([str], False),
         'execute_command': (str, False),
+        'extra_arguments': ([str], False),
+        'guest_os_type': (validator.string_list_item([UNIX, WINDOWS]), False),
         'facter': (dict, False),
         'hiera_config_path': (str, False),
         'ignore_exit_codes': (validator.boolean, False),
@@ -272,9 +268,11 @@ class PuppetServer(PackerProvisioner):
         'client_private_key_path': (str, False),
         'execute_command': (str, False),
         'facter': (dict, False),
+        'guest_os_type': (validator.string_list_item([UNIX, WINDOWS]), False),
         'ignore_exit_codes': (validator.boolean, False),
         'options': (str, False),
         'prevent_sudo': (validator.boolean, False),
+        'puppet_bin_dir': (str, False),
         'puppet_node': (str, False),
         'puppet_server': (str, False),
         'staging_dir': (str, False),

--- a/tests/packerlicious/test_validator.py
+++ b/tests/packerlicious/test_validator.py
@@ -122,6 +122,9 @@ class TestValidator(unittest.TestCase):
         for s in ['/%s/' % ('a'*511), '/%s/' % ('a'*1025)]:
             with pytest.raises(ValueError):
                 iam_path(s)
+        for s in ['%s' % ('a'*5)]:
+            with pytest.raises(ValueError):
+                iam_path(s)
 
     def test_iam_role_name(self):
         for s in ['a'*30, 'a'*64]:


### PR DESCRIPTION
### Issue
closes #72 

### List of Changes Proposed
Add guest_os_type options for puppet provisioner

### Testing Evidence
Example Script
```python
from packerlicious import provisioner, Template

provisioners = [
    provisioner.PuppetMasterless(manifest_file="site.pp", guest_os_type="windows"),
    provisioner.PuppetServer(guest_os_type="unix")
]

t = Template()
t.add_provisioner(provisioners)

print(t.to_json())
```
Results
```json
{
  "provisioners": [
    {
      "guest_os_type": "windows",
      "manifest_file": "site.pp",
      "type": "puppet-masterless"
    },
    {
      "guest_os_type": "unix",
      "type": "puppet-server"
    }
  ]
}
```
If the value provided is not in `["windows", "unix"]` following error
```bash
ValueError: String must be one of following: unix, windows
```