### PR TITLE
Install packer for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then requirementsFile="requirements-travis-26.txt"; fi
   - pip install -r $requirementsFile
 script:
+  - ./tools/get-packer.sh
   - tox
 after_success:
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then coveralls; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python --version
   - pip install -r %requirementsFile%
+  - powershell tools\get-packer.ps1
 
 build: off
 

--- a/tools/get-packer.ps1
+++ b/tools/get-packer.ps1
@@ -1,0 +1,16 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$latestVersion = [string](((Invoke-RestMethod -Uri https://releases.hashicorp.com/packer/) -split "\n" | select-string -pattern "(\d+\.){2,3}\d+" | foreach {$_.matches} | select -expandproperty value) | %{[System.Version]$_} | sort | select -last 1)
+Write-Host "Latest version is $latestVersion"
+$url = "https://releases.hashicorp.com/packer/$latestVersion/packer_${latestVersion}_windows_amd64.zip"
+Write-Host "Download link is $url"
+$output = "$PSScriptRoot\packer.zip"
+
+Write-Host "Going to start download"
+(New-Object System.Net.WebClient).DownloadFile($url, $output)
+Write-Host "Finished download. Going to unzip"
+$extractPath = (get-item $PSScriptRoot).parent.FullName
+$shell = new-object -com shell.application
+$zip = $shell.NameSpace($output)
+foreach($item in $zip.items()) {
+	$shell.Namespace("$extractPath").copyhere($item)
+}

--- a/tools/get-packer.sh
+++ b/tools/get-packer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+LATEST_PACKER=`curl https://releases.hashicorp.com/packer/ | grep -Po 'packer_(\d+\.){2,3}\d+' | sort -V | tail -1`
+set -- "$LATEST_PACKER"
+IFS="_"; declare -a Elements=($*)
+PACKER_VERSION="${Elements[1]}"
+echo "Latest Packer version is ${PACKER_VERSION}"
+wget --quiet "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${LATEST_PACKER}_linux_amd64.zip"
+unzip "${LATEST_PACKER}_linux_amd64.zip" -d ../


### PR DESCRIPTION
### Issue
Fixes #63 

### List of Changes Proposed
Add a bash script which downloads the latest available version of Packer and unzips it.

### Testing Evidence
Not yet tested. Need to check if the CI environment has the tools required by the shell script.
