### PR TITLE
Add ip network (cidr) validation

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,3 @@
 coveralls
+ipaddress
 tox-travis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 future
+ipaddress

--- a/src/packerlicious/validator.py
+++ b/src/packerlicious/validator.py
@@ -18,6 +18,8 @@ limitations under the License.
 """
 from re import compile
 
+import sys
+
 
 def boolean(x):
     if x in [True, 1, '1', 'true', 'True']:
@@ -58,6 +60,17 @@ def network_port(x):
     if int(i) < -1 or int(i) > 65535:
         raise ValueError("network port %r must been between 0 and 65535" % i)
     return x
+
+
+def network_cidr(cidr):
+    import ipaddress
+
+    # for py2.x support ensure we use unicode
+    if sys.version_info[0] < 3 and not isinstance(cidr, unicode):
+            cidr = unicode(cidr)
+
+    if ipaddress.ip_network(cidr):
+        return cidr
 
 
 def tg_healthcheck_port(x):

--- a/tests/packerlicious/test_validator.py
+++ b/tests/packerlicious/test_validator.py
@@ -6,7 +6,7 @@ import pytest
 
 from thirdparty.troposphere import Parameter, Ref
 from packerlicious.validator import boolean, integer, integer_range
-from packerlicious.validator import network_port
+from packerlicious.validator import network_cidr, network_port
 from packerlicious.validator import tg_healthcheck_port
 from packerlicious.validator import s3_bucket_name, encoding, status
 from packerlicious.validator import iam_path, iam_names, iam_role_name
@@ -59,6 +59,17 @@ class TestValidator(unittest.TestCase):
     def test_network_port_ref(self):
         p = Parameter('myport')
         network_port(Ref(p))
+
+    def test_network_cidr(self):
+        for x in ['12.14.0.0/18', u'192.168.2.0/24', '10.0.0.0/9',
+                  '0.0.0.0/0', '172.16.0.0/14', '8.7.0.0/29',
+                  '2001:db8::/48', u'2001::/56', '127.0.0.0/32']:
+            network_cidr(x)
+        for x in ['127.0.0.0/33', '127.0.0.0/-1', u'127.0.0.300/28',
+                  '2001:db8::2:1/256', '2001:db8:::9999/56',
+                  '2001:db8::2:1/56', u'::ffff:192.0.2.100/48']:
+            with pytest.raises(ValueError):
+                network_cidr(x)
 
     def test_tg_healthcheck_port(self):
         for x in ["traffic-port"]:


### PR DESCRIPTION
Uses a backport of the Python 3.3 ipaddress library
for Python 2.x implementation.

Fixes #80

### Issue
https://github.com/mayn/packerlicious/issues/80

### List of Changes Proposed
Added a dependency for a backport from a Python 3.3 module
Had to add unicode string handling as part of the implementation due to the expectation of unicode in the Python 3.3 module.
Added both positive and negative tests covering each of IPv4 and IPv6 formats.

### Testing Evidence
  py26: commands succeeded
  py27: commands succeeded
SKIPPED:  py33: InterpreterNotFound: python3.3
SKIPPED:  py34: InterpreterNotFound: python3.4
SKIPPED:  py35: InterpreterNotFound: python3.5
  py36: commands succeeded
  congratulations :)