### PR TITLE
Add Docker metadata example

### DIFF
--- a/examples/docker_metadata_example.py
+++ b/examples/docker_metadata_example.py
@@ -1,0 +1,26 @@
+# https://www.packer.io/docs/builders/docker.html#basic-example-changes-to-metadata
+from packerlicious import builder, Ref, Template, UserVar
+
+builders = [
+    builder.Docker(
+        image="ubuntu",
+        commit=True,
+        changes=[
+            "USER www-data",
+            "WORKDIR /var/www",
+            "ENV HOSTNAME www.example.com",
+            "VOLUME /test1 /test2",
+            "EXPOSE 80 443",
+            "LABEL version=1.0",
+            "ONBUILD RUN date",
+            "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
+            "ENTRYPOINT /var/www/start.sh"
+        ]
+    )
+]
+
+
+t = Template()
+t.add_builder(builders)
+
+print(t.to_json())


### PR DESCRIPTION
### Issue
#17 

### List of Changes Proposed
Add a simple Docker example, following [Packer's example for changing metadata](https://www.packer.io/docs/builders/docker.html#basic-example-changes-to-metadata). The link is also included at the top of the example.

### Testing Evidence

#### Resulting JSON:
<img width="578" alt="screen shot 2017-10-23 at 6 46 08 pm" src="https://user-images.githubusercontent.com/2058067/31921127-776bc84a-b822-11e7-9f4b-826acd660a7e.png">

#### Packer docs:
<img width="891" alt="screen shot 2017-10-23 at 6 46 46 pm" src="https://user-images.githubusercontent.com/2058067/31921140-8cfba9b4-b822-11e7-843f-3679f5b70e3e.png">
