### PR TITLE
Add hyperv-vmcx builder

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -800,6 +800,54 @@ class HyperV(PackerBuilder):
         'temp_path': (str, False),
     }
 
+class HyperVvmcx(PackerBuilder):
+    """
+    Hyper-V Builder (from a vmcx)
+    https://www.packer.io/docs/builders/hyperv-vmcx.html
+    """
+    resource_type = "hyperv-vmcx"
+
+    props = {
+        'clone_from_vmxc_path': (str, True),
+        'clone_from_vm_name': (str, True),
+        'clone_from_snapshot_name': (str, False),
+        'clone_all_snapshots': (validator.boolean, False),
+        'boot_command': ([str], False),
+        'boot_wait': (str, False),
+        'cpu': (int, False),
+        'enable_dynamic_memory': (validator.boolean, False),
+        'enable_mac_spoofing': (validator.boolean, False),
+        'enable_secure_boot': (validator.boolean, False),
+        'enable_virtualization_extensions': (validator.boolean, False),
+        'floppy_files': ([str], False),
+        'floppy_dirs': ([str], False),
+        'guest_additions_mode': (str, False),
+        'guest_additions_path': (str, False),
+        'http_directory': (str, False),
+        'http_port_min': (int, False),
+        'http_port_max': (int, False),
+        'iso_url': (str, False),
+        'iso_urls': ([str], False),
+        'iso_target_extension': (str, False),
+        'iso_target_path': (str, False),
+        'output_directory': (str, False),
+        'ram_size': (int, False),
+        'secondary_iso_images': ([str], False),
+        'shutdown_command': (str, False),
+        'shutdown_timeout': (str, False),
+        'skip_compaction': (validator.boolean, False),
+        'switch_name': (str, False),
+        'switch_vlan_id': (str, False),
+        'vlan_id': (str, False),
+        'vm_name': (str, False),
+    }
+
+    def validate(self):
+        conds = [
+            'clone_from_vmxc_path',
+            'clone_from_vm_name'
+        ]
+        validator.exactly_one(self.__class__.__name__, self.properties, conds)
 
 class LXD(PackerBuilder):
     """

--- a/tests/packerlicious/test_builder_hyperv_vmcx.py
+++ b/tests/packerlicious/test_builder_hyperv_vmcx.py
@@ -1,0 +1,24 @@
+import pytest
+
+import packerlicious.builder as builder
+
+
+class TestHyperVvmcxBuilder(object):
+
+    def test_required_fields_missing(self):
+        b = builder.HyperVvmcx()
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'required' in str(excinfo.value)
+
+    def test_exactly_one_clone(self):
+        b = builder.HyperVvmcx(
+            clone_from_vmxc_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
+            clone_from_vm_name="ubuntu-12.04.5-server-amd64"
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'HyperVvmcx: only one of the following can be specified: clone_from_vmxc_path, clone_from_vm_name' == str(
+            excinfo.value)


### PR DESCRIPTION
### Issue
#66

### List of Changes Proposed
Add hyperv-vmcx builder

### Testing Evidence
```bash
  py26: commands succeeded
  py27: commands succeeded
SKIPPED:  py33: InterpreterNotFound: python3.3
SKIPPED:  py34: InterpreterNotFound: python3.4
SKIPPED:  py35: InterpreterNotFound: python3.5
SKIPPED:  py36: InterpreterNotFound: python3.6
  congratulations :)
```