### PR TITLE
Add checks for list of list type

### DIFF
--- a/src/thirdparty/troposphere/__init__.py
+++ b/src/thirdparty/troposphere/__init__.py
@@ -160,7 +160,17 @@ class BaseAWSObject(object):
                 # type checks (as above accept AWSHelperFn because
                 # we can't do the validation ourselves)
                 for v in value:
-                    if not isinstance(v, tuple(expected_type)) \
+                    # If we're expecting a list of list with the same type
+                    if isinstance(v, list):
+                        # Double check that it's a list of list
+                        if not all(isinstance(elem, list) for elem in value):
+                            self._raise_type(name, v, expected_type)
+                        # Make sure all elements in list are of the expected_type[0][0]
+                        else:
+                            for elem in v:
+                                if not isinstance(elem, expected_type[0][0]):
+                                    self._raise_type(name, elem, expected_type[0][0])
+                    elif not isinstance(v, tuple(expected_type)) \
                        and not isinstance(v, AWSHelperFn):
                         self._raise_type(name, v, expected_type)
                 # Validated so assign it

--- a/tests/packerlicious/test_template.py
+++ b/tests/packerlicious/test_template.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import sys
 
 from packerlicious import UserVar, Template
 from packerlicious import builder, post_processor, provisioner
@@ -202,8 +203,11 @@ class TestPackerTemplate(object):
       ]
     }
     """
-    exception_1 = "<class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <type 'list'>, expected [[<type 'str'>]]"
-    exception_2 = "<class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <type 'int'>, expected <type 'str'>"
+    assertion = 'type' if sys.version_info[0] < 3 else 'class'
+    exception_1 = "<class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <" + assertion \
+                  + " 'list'>, expected [[<" + assertion +  " 'str'>]]"
+    exception_2 = "<class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <" + assertion\
+                  + " 'int'>, expected <" + assertion + " 'str'>"
     @pytest.mark.parametrize('test_input,exception,expected', [
         pytest.param(
             [['modifyvm {{.Name}} --memory 1024'], ['modifyvm {{.Name}} --cpus 1']],

--- a/tests/packerlicious/test_template.py
+++ b/tests/packerlicious/test_template.py
@@ -139,3 +139,142 @@ class TestPackerTemplate(object):
         assert to_json == json.dumps(json.loads(expected_json), sort_keys=True, indent=2,
                                      separators=(',', ': '))
 
+
+    expected_json_1 = """
+    {
+      "builders": [
+        {
+          "boot_wait": "10s",
+          "floppy_files": [
+            ""
+          ],
+          "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+          "guest_os_type": "Ubuntu_64",
+          "http_directory": "",
+          "iso_checksum": "sha512",
+          "iso_checksum_type": "sha512",
+          "iso_url": "",
+          "ssh_port": 22,
+          "type": "virtualbox-iso",
+          "vboxmanage": [
+            [
+              "modifyvm {{.Name}} --memory 1024"
+            ],
+            [
+              "modifyvm {{.Name}} --cpus 1"
+            ]
+          ],
+          "virtualbox_version_file": ".vbox_version",
+          "vm_name": ""
+        }
+      ]
+    }
+    """
+    expected_json_2 = """
+    {
+      "builders": [
+        {
+          "boot_wait": "10s",
+          "floppy_files": [
+            ""
+          ],
+          "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+          "guest_os_type": "Ubuntu_64",
+          "http_directory": "",
+          "iso_checksum": "sha512",
+          "iso_checksum_type": "sha512",
+          "iso_url": "",
+          "ssh_port": 22,
+          "type": "virtualbox-iso",
+          "vboxmanage": [
+            [
+              "modifyvm {{.Name}} --memory 1024"
+            ],
+            [
+              "modifyvm",
+              "{{.Name}}",
+              "--cpus 1"
+            ]
+          ],
+          "virtualbox_version_file": ".vbox_version",
+          "vm_name": ""
+        }
+      ]
+    }
+    """
+    exception_1 = "<class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <type 'list'>, expected [[<type 'str'>]]"
+    exception_2 = "<class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <type 'int'>, expected <type 'str'>"
+    @pytest.mark.parametrize('test_input,exception,expected', [
+        pytest.param(
+            [['modifyvm {{.Name}} --memory 1024'], ['modifyvm {{.Name}} --cpus 1']],
+            False,
+            expected_json_1,
+            marks=pytest.mark.basic
+        ),
+        pytest.param(
+            [['modifyvm {{.Name}} --memory 1024'], ['modifyvm', '{{.Name}}', '--cpus 1']],
+            False,
+            expected_json_2,
+            marks=pytest.mark.basic
+        ),
+        pytest.param(
+            [['modifyvm {{.Name}} --memory 1024'], 1],
+            True,
+            exception_1,
+            marks=pytest.mark.basic
+        ),
+        pytest.param(
+            [['modifyvm {{.Name}} --memory 1024'], [1]],
+            True,
+            exception_2,
+            marks=pytest.mark.basic
+        )
+    ])
+    def test_list_of_list_type_check(self, test_input, exception, expected):
+
+        t = Template()
+        HTTP_DIR = ""
+        ISO_URL = ""
+        ISO_CHECKSUM_TYPE = "sha512"
+        ISO_CHECKSUM = "sha512"
+        VM_NAME = ""
+        VBOX_MANAGE=test_input
+        if exception:
+            with pytest.raises(TypeError) as excinfo:
+                t.add_builder(
+                    builder.VirtualboxIso(
+                        boot_wait="10s",
+                        guest_os_type="Ubuntu_64",
+                        http_directory=HTTP_DIR,
+                        iso_url=ISO_URL,
+                        iso_checksum_type=ISO_CHECKSUM_TYPE,
+                        iso_checksum=ISO_CHECKSUM,
+                        ssh_port=22,
+                        guest_additions_path="VBoxGuestAdditions_{{.Version}}.iso",
+                        virtualbox_version_file=".vbox_version",
+                        vm_name=VM_NAME,
+                        floppy_files=[""],
+                        vboxmanage=VBOX_MANAGE
+                    )
+                )
+            assert expected == str(excinfo.value)
+        else:
+            t.add_builder(
+                builder.VirtualboxIso(
+                    boot_wait="10s",
+                    guest_os_type="Ubuntu_64",
+                    http_directory=HTTP_DIR,
+                    iso_url=ISO_URL,
+                    iso_checksum_type=ISO_CHECKSUM_TYPE,
+                    iso_checksum=ISO_CHECKSUM,
+                    ssh_port=22,
+                    guest_additions_path="VBoxGuestAdditions_{{.Version}}.iso",
+                    virtualbox_version_file=".vbox_version",
+                    vm_name=VM_NAME,
+                    floppy_files=[""],
+                    vboxmanage=VBOX_MANAGE
+                )
+            )
+            to_json = t.to_json()
+            assert to_json == json.dumps(json.loads(expected), sort_keys=True, indent=2,
+                                     separators=(',', ': '))


### PR DESCRIPTION
### Issue
#91 

### List of Changes Proposed
In the 3rd party tool code for [troposphere](https://github.com/cloudtools/troposphere) does not consider the case of having a list of lists.

### Testing Evidence
Posting the sample script used in the issue for reference.
```python
from packerlicious import builder, Template
import sys

template = Template()

HTTP_DIR = ""
ISO_URL = ""
ISO_CHECKSUM_TYPE = "sha512"
ISO_CHECKSUM = "sha512"
VM_NAME = ""
VBOX_MANAGE=sys.argv[1]

template.add_builder(
    builder.VirtualboxIso(
        boot_wait="10s",
        guest_os_type="Ubuntu_64",
        http_directory=HTTP_DIR,
        iso_url=ISO_URL,
        iso_checksum_type=ISO_CHECKSUM_TYPE,
        iso_checksum=ISO_CHECKSUM,
        ssh_port=22,
        # shutdown_command=f'echo {ssh_pass} | sudo -S shutdown -P now',
        guest_additions_path="VBoxGuestAdditions_{{.Version}}.iso",
        virtualbox_version_file=".vbox_version",
        vm_name=VM_NAME,
        floppy_files=[""],
        vboxmanage=VBOX_MANAGE
    )
)

print(template.to_json())

```
Running sample script with different input values.
```bash
issue_91.py [['modifyvm {{.Name}} --memory 1024'], 1]
Traceback (most recent call last):
  File "/Users/mprince/projects/packerlicious/examples/issue_91.py", line 30, in <module>
    vboxmanage=VBOX_MANAGE
  File "/Users/mprince/projects/packerlicious/src/packerlicious/builder.py", line 73, in __init__
    super(PackerBuilder, self).__init__(title, **kwargs)
  File "/Users/mprince/projects/packerlicious/src/packerlicious/builder.py", line 67, in __init__
    super(PackerCommunicator, self).__init__(title, **kwargs)
  File "/Users/mprince/projects/packerlicious/src/thirdparty/troposphere/__init__.py", line 97, in __init__
    self.__setattr__(k, v)
  File "/Users/mprince/projects/packerlicious/src/thirdparty/troposphere/__init__.py", line 157, in __setattr__
    self._raise_type(name, value, expected_type)
  File "/Users/mprince/projects/packerlicious/src/thirdparty/troposphere/__init__.py", line 203, in _raise_type
    expected_type))
TypeError: <class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <type 'str'>, expected [[<type 'str'>]]

issue_91.py [['modifyvm {{.Name}} --memory 1024'], [1]]
Traceback (most recent call last):
  File "/Users/mprince/projects/packerlicious/examples/issue_91.py", line 30, in <module>
    vboxmanage=VBOX_MANAGE
  File "/Users/mprince/projects/packerlicious/src/packerlicious/builder.py", line 73, in __init__
    super(PackerBuilder, self).__init__(title, **kwargs)
  File "/Users/mprince/projects/packerlicious/src/packerlicious/builder.py", line 67, in __init__
    super(PackerCommunicator, self).__init__(title, **kwargs)
  File "/Users/mprince/projects/packerlicious/src/thirdparty/troposphere/__init__.py", line 97, in __init__
    self.__setattr__(k, v)
  File "/Users/mprince/projects/packerlicious/src/thirdparty/troposphere/__init__.py", line 157, in __setattr__
    self._raise_type(name, value, expected_type)
  File "/Users/mprince/projects/packerlicious/src/thirdparty/troposphere/__init__.py", line 203, in _raise_type
    expected_type))
TypeError: <class 'packerlicious.builder.VirtualboxIso'>: None.vboxmanage is <type 'str'>, expected [[<type 'str'>]]

issue_91.py [['modifyvm {{.Name}} --memory 1024'], ['modifyvm {{.Name}} --cpus 1']]
{
  "builders": [
    {
      "boot_wait": "10s",
      "floppy_files": [
        ""
      ],
      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
      "guest_os_type": "Ubuntu_64",
      "http_directory": "",
      "iso_checksum": "sha512",
      "iso_checksum_type": "sha512",
      "iso_url": "",
      "ssh_port": 22,
      "type": "virtualbox-iso",
      "vboxmanage": [
        [
          "modifyvm {{.Name}} --memory 1024"
        ],
        [
          "modifyvm {{.Name}} --cpus 1"
        ]
      ],
      "virtualbox_version_file": ".vbox_version",
      "vm_name": ""
    }
  ]
}

issue_91.py [['modifyvm {{.Name}} --memory 1024'], ['modifyvm', '{{.Name}}', '--cpus 1']]
{
  "builders": [
    {
      "boot_wait": "10s",
      "floppy_files": [
        ""
      ],
      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
      "guest_os_type": "Ubuntu_64",
      "http_directory": "",
      "iso_checksum": "sha512",
      "iso_checksum_type": "sha512",
      "iso_url": "",
      "ssh_port": 22,
      "type": "virtualbox-iso",
      "vboxmanage": [
        [
          "modifyvm {{.Name}} --memory 1024"
        ],
        [
          "modifyvm",
          "{{.Name}}",
          "--cpus 1"
        ]
      ],
      "virtualbox_version_file": ".vbox_version",
      "vm_name": ""
    }
  ]
}
```