### PR TITLE
builder/hyperv - rename HyperV builders

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -755,9 +755,9 @@ class GoogleCompute(PackerBuilder):
     }
 
 
-class HyperV(PackerBuilder):
+class HypervIso(PackerBuilder):
     """
-    Hyper-V Builder
+    Hyper-V Builder (from an ISO)
     https://www.packer.io/docs/builders/hyperv-iso.html
     """
     resource_type = "hyperv-iso"
@@ -800,7 +800,7 @@ class HyperV(PackerBuilder):
     }
 
 
-class HyperVvmcx(PackerBuilder):
+class HypervVmcx(PackerBuilder):
     """
     Hyper-V Builder (from a vmcx)
     https://www.packer.io/docs/builders/hyperv-vmcx.html

--- a/tests/packerlicious/test_builder_hyperv.py
+++ b/tests/packerlicious/test_builder_hyperv.py
@@ -3,38 +3,38 @@ import pytest
 import packerlicious.builder as builder
 
 
-class TestHyperVBuilder(object):
+class TestHypervIsoBuilder(object):
 
     def test_required_fields_missing(self):
-        b = builder.HyperV()
+        b = builder.HypervIso()
 
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
         assert 'required' in str(excinfo.value)
 
 
-class TestHyperVvmcxBuilder(object):
+class TestHypervVmcxBuilder(object):
 
     def test_required_fields_missing(self):
-        b = builder.HyperVvmcx()
+        b = builder.HypervVmcx()
 
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
-        assert 'HyperVvmcx: one of the following must be specified: clone_from_vmxc_path, clone_from_vm_name' == str(excinfo.value)
+        assert 'HypervVmcx: one of the following must be specified: clone_from_vmxc_path, clone_from_vm_name' == str(excinfo.value)
 
     def test_exactly_one_clone_from_required(self):
-        b = builder.HyperVvmcx(
+        b = builder.HypervVmcx(
             clone_from_vmxc_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
             clone_from_vm_name="ubuntu-12.04.5-server-amd64"
         )
 
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
-        assert 'HyperVvmcx: only one of the following can be specified: clone_from_vmxc_path, clone_from_vm_name' == str(
+        assert 'HypervVmcx: only one of the following can be specified: clone_from_vmxc_path, clone_from_vm_name' == str(
             excinfo.value)
 
     def test_exactly_one_clone_from_specified(self):
-        b = builder.HyperVvmcx(
+        b = builder.HypervVmcx(
             clone_from_vmxc_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
         )
 


### PR DESCRIPTION
### Issue
fixes https://github.com/mayn/packerlicious/issues/93

### List of Changes Proposed
renaming of hyperv builders
-  HyperV to HypervIso
- HyperVvmcx to HypervVmcx


### Testing Evidence
<!-- surely this change was tested, show the evidence -->
