### PR TITLE
Changed VMwareIso in builder so that it has format prop

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -1339,6 +1339,7 @@ class VMwareIso(PackerBuilder):
         'disable_vnc': (validator.boolean, False),
         'floppy_files': ([str], False),
         'floppy_dirs': ([str], False),
+        'format': (validator.string_list_item(['ovf','ova','vmx']), False),
         'fusion_app_path': (str, False),
         'guest_os_type': (str, False),
         'headless': (validator.boolean, False),


### PR DESCRIPTION
### Issue
https://github.com/mayn/packerlicious/issues/103


### List of Changes Proposed
Added 'format' prop to VMwareIso method in builder.py file.

### Testing Evidence
<!-- surely this change was tested, show the evidence -->
Ran this in Python terminal.
![screen shot 2018-04-19 at 6 14 04 pm](https://user-images.githubusercontent.com/13742282/39025646-43d510ba-43fd-11e8-9043-465a315ad2ab.png)