### PR TITLE
Added two parameters for Qemu in builder.py

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -1237,6 +1237,8 @@ class Qemu(PackerBuilder):
         'output_directory': (str, False),
         'qemu_binary': (str, False),
         'qemuargs': (validator.jagged_array(str), False),
+        'shutdown_command': (str, False),
+        'vm_name': (str, False)
     }
 
     def validate(self):


### PR DESCRIPTION
### Issue
Noticed there were a few parameters for the Qemu builder missing.


### List of Changes Proposed
Added shutdown_command and vm_name to the builder.


### Testing Evidence
-
