### PR TITLE
Added add_post_processor_chain function

### DIFF
--- a/src/packerlicious/template.py
+++ b/src/packerlicious/template.py
@@ -83,6 +83,9 @@ class Template(object):
 
     def add_post_processor(self, post_processor):
         return self._update(self.post_processors, post_processor)
+    
+    def add_post_processor_chain(self, *args):
+        return self._update(self.post_processors, [args])
 
     def to_dict(self):
         t = {}


### PR DESCRIPTION
### Issue
#115 


### List of Changes Proposed
Adding Post Processor Chain since its not implemented yet.


### Testing Evidence
~~~
>>> from packerlicious import post_processor, Template
>>> test_template = Template()
>>> file_post = post_processor.Checksum()
>>> file_post2 = post_processor.Artifice(files = ['testfile.test'])
>>> test_template.add_post_processor_chain(file_post,file_post2)
>>> print(test_template.to_json())
{
  "post-processors": [
    [
      {
        "type": "checksum"
      },
      {
        "files": [
          "testfile.test"
        ],
        "type": "artifice"
      }
    ]
  ]
}
~~~
