### PR TITLE
s3_key_name added to AmazonImport

### DIFF
--- a/src/packerlicious/post_processor.py
+++ b/src/packerlicious/post_processor.py
@@ -81,6 +81,7 @@ class AmazonImport(PackerPostProcessor):
         'mfa_code': (str, False),
         'profile': (str, False),
         'role_name': (str, False),
+        's3_key_name': (str, False),
         'skip_clean': (validator.boolean, False),
         'skip_region_validation': (validator.boolean, False),
         'tags': (dict, False),


### PR DESCRIPTION
### List of Changes Proposed
Adding s3_key_name to AmazonImport so amazon import builds don't have 'packer-<buildname>.ova'


### Testing Evidence
```
>>> template = Template()
>>> amazon = post_processor.AmazonImport(
... access_key = 'xxxx',
... region = 'us-west',
... s3_bucket_name = 'xxxx',
... secret_key = 'secret',
... s3_key_name = 'testname')
>>> template.add_post_processor(amazon)
<packerlicious.post_processor.AmazonImport object at 0x104ef7e50>
>>> print template.to_json()
{
  "post-processors": [
    {
      "access_key": "xxxx",
      "region": "us-west",
      "s3_bucket_name": "xxxx",
      "s3_key_name": "testname",
      "secret_key": "secret",
      "type": "amazon-import"
    }
  ]
}
```
