### PR TITLE
[googlecompute] Add support for specifying `image_labels` dict.

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -806,6 +806,7 @@ class GoogleCompute(PackerBuilder):
         'disk_type': (str, False),
         'image_description': (str, False),
         'image_family': (str, False),
+        'image_labels': (dict, False),
         'image_licenses': ([str], False),
         'image_name': (str, False),
         'instance_name': (str, False),


### PR DESCRIPTION
Ref: https://www.packer.io/docs/builders/googlecompute.html#image_labels