### PR TITLE
Shutdown behavior is a string per packer documentation. Does not acce…

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -215,7 +215,7 @@ class AmazonEbs(PackerBuilder):
         'run_volume_tags': (dict, False),
         'security_group_id': (str, False),
         'security_group_ids': ([str], False),
-        'shutdown_behavior': (str`, False),
+        'shutdown_behavior': (str, False),
         'skip_region_validation': (validator.boolean, False),
         'snapshot_groups': ([str], False),
         'snapshot_users': ([str], False),


### PR DESCRIPTION
Shutdown behavior is a string per packer documentation. Does not accept a string in a list

### Issue
<!-- Link to the issue being addressed -->
https://github.com/mayn/packerlicious/issues/122

### List of Changes Proposed
<!-- what is being changed and why? -->
Changing validation from [str] to str

### Testing Evidence
<!-- surely this change was tested, show the evidence -->
Packer validate no longer throws an error as described in the issue.