### PR TITLE
AmazonChroot: validate required options when from_scratch is true

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -317,11 +317,28 @@ class AmazonChroot(PackerBuilder):
         ]
         validator.all_or_nothing(self.__class__.__name__, self.properties, conds)
 
-        conds = [
-            'source_ami',
-            'source_ami_filter',
+        from_scratch_conds = [
+            'ami_virtualization_type',
+            'pre_mount_commands',
+            'root_volume_size'
         ]
-        validator.exactly_one(self.__class__.__name__, self.properties, conds)
+
+        if (
+            'from_scratch' in self.properties and
+            self.properties['from_scratch'] == 'true' and
+            validator.count(self.properties, from_scratch_conds) != 3
+        ):
+            raise ValueError(
+                "AmazonChroot: when from_config is True, source_ami "
+                "is ignored and {0} options are "
+                "required".format(', '.join(from_scratch_conds)))
+        else:
+            conds = [
+                'source_ami',
+                'source_ami_filter',
+            ]
+            validator.exactly_one(
+                self.__class__.__name__, self.properties, conds)
 
 
 class AmazonEbsSurrogate(PackerBuilder):

--- a/tests/packerlicious/test_builder_amazon.py
+++ b/tests/packerlicious/test_builder_amazon.py
@@ -108,6 +108,33 @@ class TestAmazonChroot(object):
             b.to_dict()
         assert 'AmazonChroot: one of the following must be specified: source_ami, source_ami_filter' == str(excinfo.value)
 
+    def test_exactly_one_source_ami_when_from_scratch_is_false(self):
+        b = builder.AmazonChroot(
+            ami_name  ="some-ami",
+            access_key="dummy-access-key",
+            secret_key="dummy-secret-key",
+            from_scratch="false"
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'AmazonChroot: one of the following must be specified: source_ami, source_ami_filter' == str(excinfo.value)
+
+    def test_required_fields_when_from_scratch_is_true(self):
+        b = builder.AmazonChroot(
+            ami_name  ="some-ami",
+            access_key="dummy-access-key",
+            secret_key="dummy-secret-key",
+            from_scratch="true"
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'AmazonChroot: when from_config is True, source_ami is ' \
+               'ignored and ami_virtualization_type, pre_mount_commands, ' \
+               'root_volume_size options are required' == str(excinfo.value)
+
+
 class TestAmazonEbsSurrogate(object):
 
     def test_required_fields_missing(self):


### PR DESCRIPTION
### Issue
Fixes #126.


### List of Changes Proposed
Add validation for required options when `from_scratch` option is set to True.


### Testing Evidence
See added unit tests.
