### PR TITLE
Add root_volume_type prop for AmazonChroot builder

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -301,6 +301,7 @@ class AmazonChroot(PackerBuilder):
         'profile': (str, False),
         'post_mount_commands': ([str], False),
         'root_volume_size': (int, False),
+        'root_volume_type': (str, False),
         'skip_region_validation': (validator.boolean, False),
         'snapshot_tags': ([str], False),
         'snapshot_groups': ([str], False),


### PR DESCRIPTION
### Issue
#125


### List of Changes Proposed
Adds root_volume_type prop to AmazonChroot builder.


### Testing Evidence

