### PR TITLE
#122 correct shutdown_behavior type for AmazonEbsSurrogate and AmazonEbsVolume

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ Provisioners:
 
 
 Community Plugins:
+
 - packer-provisioner-inspec
 
 Licensing

--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -390,7 +390,7 @@ class AmazonEbsSurrogate(PackerBuilder):
         'run_volume_tags': (dict, False),
         'security_group_id': (str, False),
         'security_group_ids': ([str], False),
-        'shutdown_behavior': ([str], False),
+        'shutdown_behavior': (str, False),
         'skip_region_validation': (validator.boolean, False),
         'snapshot_groups': ([str], False),
         'snapshot_users': ([str], False),
@@ -465,7 +465,7 @@ class AmazonEbsVolume(PackerBuilder):
         'run_tags': (dict, False),
         'security_group_id': (str, False),
         'security_group_ids': ([str], False),
-        'shutdown_behavior': ([str], False),
+        'shutdown_behavior': (str, False),
         'skip_region_validation': (validator.boolean, False),
         'snapshot_groups': ([str], False),
         'snapshot_users': ([str], False),
@@ -517,7 +517,7 @@ class AmazonInstance(PackerBuilder):
     """
     AWS Instance Template Variables
     https://www.packer.io/docs/builders/amazon-ebs.html#ami_description
-    TODO impl validation ami_virtualization_type region_kms_key_ids run_volume_tags shutdown_behavior
+    TODO impl validation ami_virtualization_type region_kms_key_ids run_volume_tags
             spot_price_auto_product ssh_keypair_name
     """
     SourceAMI = TemplateVar("SourceAMI")


### PR DESCRIPTION
### Issue
fixes #122
completes remainder of #123

### List of Changes Proposed
changes type from `[str]` to `str` for AmazonEbsSurrogate and AmazonEbsVolume
