### PR TITLE
Fix for issue 127 setting source_ami_filter:owners to be required

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -142,7 +142,7 @@ class AmazonSourceAmiFilter(PackerProperty):
     """
     props = {
         'filters': (dict, False),
-        'owners': ([str], False),
+        'owners': ([str], True),
         'most_recent': (validator.boolean, False),
     }
 


### PR DESCRIPTION
### Issue
https://github.com/mayn/packerlicious/issues/127


### List of Changes Proposed
 Make source_ami_filter "owners" required


