### PR TITLE
change python version used to submit to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
   - ./tools/get-packer.sh
   - tox
 after_success:
-  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then coveralls; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ]; then coveralls; fi


### PR DESCRIPTION
error being generated on travis side

```
$ if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then coveralls; fi
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.24) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/bin/coveralls", line 7, in <module>
    from coveralls.cli import main
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/coveralls/__init__.py", line 2, in <module>
    from .api import Coveralls
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/coveralls/api.py", line 9, in <module>
    import requests
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/__init__.py", line 112, in <module>
    from . import utils
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/utils.py", line 26, in <module>
    from ._internal_utils import to_native_string
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/_internal_utils.py", line 11, in <module>
    from .compat import is_py2, builtin_str, str
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/compat.py", line 48, in <module>
    from urllib3.packages.ordered_dict import OrderedDict
ImportError: No module named ordered_dict
```


### List of Changes Proposed
<!-- what is being changed and why? -->


### Testing Evidence
<!-- surely this change was tested, show the evidence -->
