### PR TITLE
builder/GoogleCompute add  min_cpu_platform support

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -837,6 +837,7 @@ class GoogleCompute(PackerBuilder):
         'instance_name': (str, False),
         'machine_type': (str, False),
         'metadata': (dict, False),
+        'min_cpu_platform': (str, False),
         'network': (str, False),
         'network_project_id': (str, False),
         'omit_external_ip': (validator.boolean, False),


### PR DESCRIPTION
### Issue
fixes #144
### List of Changes Proposed
Packer added an optional min_cpu_platform option. https://www.packer.io/docs/builders/googlecompute.html#min_cpu_platform
