### PR TITLE
Add block_duration_minutes to AWS resources

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -198,6 +198,9 @@ class AmazonEbs(PackerBuilder):
         'ami_virtualization_type': (str, False),
         'associate_public_ip_address': (validator.boolean, False),
         'availability_zone': (str, False),
+        'block_duration_minutes': (
+            validator.integer_list_item(
+                'block_duration_minutes', [60, 120, 180, 240, 300, 360]), False),
         'custom_endpoint_ec2': (str, False),
         'decode_authorization_messages': (validator.boolean, False),
         'disable_stop_instance': (validator.boolean, False),
@@ -255,6 +258,12 @@ class AmazonEbs(PackerBuilder):
         conds = [
             'security_group_id',
             'security_group_ids',
+        ]
+        validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
+
+        conds = [
+            'availability_zone',
+            'block_duration_minutes',
         ]
         validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
 
@@ -372,6 +381,9 @@ class AmazonEbsSurrogate(PackerBuilder):
         'ami_virtualization_type': (str, False),
         'associate_public_ip_address': (validator.boolean, False),
         'availability_zone': (str, False),
+        'block_duration_minutes': (
+            validator.integer_list_item(
+                'block_duration_minutes', [60, 120, 180, 240, 300, 360]), False),
         'custom_endpoint_ec2': (str, False),
         'decode_authorization_messages': (validator.boolean, False),
         'disable_stop_instance': (validator.boolean, False),
@@ -434,6 +446,12 @@ class AmazonEbsSurrogate(PackerBuilder):
         ]
         validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
 
+        conds = [
+            'availability_zone',
+            'block_duration_minutes',
+        ]
+        validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
+
 
 class AmazonEbsVolume(PackerBuilder):
     """
@@ -454,6 +472,7 @@ class AmazonEbsVolume(PackerBuilder):
         'ebs_volumes': ([BlockDeviceMapping], False),
         'associate_public_ip_address': (validator.boolean, False),
         'availability_zone': (str, False),
+        'block_duration_minutes': (validator.integer, False),
         'custom_endpoint_ec2': (str, False),
         'decode_authorization_messages': (validator.boolean, False),
         'disable_stop_instance': (validator.boolean, False),
@@ -507,6 +526,12 @@ class AmazonEbsVolume(PackerBuilder):
         ]
         validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
 
+        conds = [
+            'availability_zone',
+            'block_duration_minutes',
+        ]
+        validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
+
 
 class AmazonInstance(PackerBuilder):
     """
@@ -545,6 +570,9 @@ class AmazonInstance(PackerBuilder):
         'ami_virtualization_type': (str, False),
         'associate_public_ip_address': (validator.boolean, False),
         'availability_zone': (str, False),
+        'block_duration_minutes': (
+            validator.integer_list_item(
+                'block_duration_minutes', [60, 120, 180, 240, 300, 360]), False),
         'bundle_destination': (str, False),
         'bundle_prefix': (str, False),
         'bundle_upload_command': (str, False),
@@ -601,6 +629,12 @@ class AmazonInstance(PackerBuilder):
         conds = [
             'security_group_id',
             'security_group_ids',
+        ]
+        validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
+
+        conds = [
+            'availability_zone',
+            'block_duration_minutes',
         ]
         validator.mutually_exclusive(self.__class__.__name__, self.properties, conds)
 

--- a/src/packerlicious/validator.py
+++ b/src/packerlicious/validator.py
@@ -229,3 +229,14 @@ def jagged_array(expected_type):
             raise ValueError("%r is not a valid array of array of %r" % (x, expected_type))
 
     return jagged_array_checker
+
+
+def integer_list_item(prop_name, allowed_values):
+    def integer_list_item_checker(x):
+        s = integer(x)
+        if s in allowed_values:
+            return s
+        raise ValueError('{0} must be one of following: {1}'.format(
+                         prop_name, ', '.join(str(j) for j in allowed_values)))
+
+    return integer_list_item_checker

--- a/tests/packerlicious/test_builder_amazon.py
+++ b/tests/packerlicious/test_builder_amazon.py
@@ -49,6 +49,28 @@ class TestAmazonInstanceBuilder(object):
             b.to_dict()
         assert 'AmazonInstance: only one of the following can be specified: security_group_id, security_group_ids' == str(excinfo.value)
 
+    def test_mutually_exclusive_availability_zone_block_duration_minutes(self):
+        b = builder.AmazonInstance(
+            account_id="...",
+            access_key="dummy-access-key",
+            secret_key="dummy-secret-key",
+            instance_type="t2.micro",
+            ami_name="ami-result",
+            region="us-east-1",
+            source_ami="dummy-source-ami",
+            s3_bucket="...",
+            x509_cert_path="...",
+            x509_key_path="...",
+            security_group_id="sg-123",
+            availability_zone='zone-1',
+            block_duration_minutes=60
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'AmazonInstance: only one of the following can be specified: availability_zone, block_duration_minutes' == str(
+            excinfo.value)
+
 
 class TestAmazonEbsBuilder(object):
 
@@ -87,6 +109,25 @@ class TestAmazonEbsBuilder(object):
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
         assert 'AmazonEbs: only one of the following can be specified: security_group_id, security_group_ids' == str(excinfo.value)
+
+    def test_mutually_exclusive_availability_zone_block_duration_minutes(self):
+        b = builder.AmazonEbs(
+            access_key="dummy-access-key",
+            secret_key="dummy-secret-key",
+            instance_type="t2.micro",
+            ami_name="ami-result",
+            region="us-east-1",
+            source_ami="dummy-source-ami",
+            security_group_id="sg-123",
+            availability_zone='zone-1',
+            block_duration_minutes=60
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'AmazonEbs: only one of the following can be specified: availability_zone, block_duration_minutes' == str(
+            excinfo.value)
+
 
 class TestAmazonChroot(object):
 
@@ -177,6 +218,26 @@ class TestAmazonEbsSurrogate(object):
             b.to_dict()
         assert 'AmazonEbsSurrogate: only one of the following can be specified: security_group_id, security_group_ids' == str(excinfo.value)
 
+    def test_mutually_exclusive_availability_zone_block_duration_minutes(self):
+        ami_root_dev = builder.BlockDeviceMapping()
+        b = builder.AmazonEbsSurrogate(
+            access_key="dummy-access-key",
+            secret_key="dummy-secret-key",
+            instance_type="t2.micro",
+            source_device_name="some_device",
+            region="us-east-1",
+            ami_root_device=[ami_root_dev],
+            source_ami="dummy-source-ami",
+            security_group_ids=["sg-123", "sg-456"],
+            availability_zone='zone-1',
+            block_duration_minutes=60
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'AmazonEbsSurrogate: only one of the following can be specified: availability_zone, block_duration_minutes' == str(excinfo.value)
+
+
 class TestAmazonEbsVolume(object):
 
     def test_required_fields_missing(self):
@@ -212,3 +273,19 @@ class TestAmazonEbsVolume(object):
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
         assert 'AmazonEbsVolume: only one of the following can be specified: security_group_id, security_group_ids' == str(excinfo.value)
+
+    def test_mutually_exclusive_availability_zone_block_duration_minutes(self):
+        b = builder.AmazonEbsVolume(
+            access_key="dummy-access-key",
+            secret_key="dummy-secret-key",
+            instance_type="t2.micro",
+            region="us-east-1",
+            source_ami="dummy-source-ami",
+            security_group_id="sg-123",
+            availability_zone='zone-1',
+            block_duration_minutes=60
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'AmazonEbsVolume: only one of the following can be specified: availability_zone, block_duration_minutes' == str(excinfo.value)

--- a/tests/packerlicious/test_validator.py
+++ b/tests/packerlicious/test_validator.py
@@ -12,6 +12,7 @@ from packerlicious.validator import iam_path, iam_names, iam_role_name
 from packerlicious.validator import iam_group_name, iam_user_name, elb_name
 from packerlicious.validator import jagged_array
 from packerlicious.validator import all_or_nothing, mutually_exclusive
+from packerlicious.validator import integer_list_item
 
 
 class TestValidator(object):
@@ -189,3 +190,20 @@ class TestValidator(object):
         for i, sub_list in enumerate(test_value):
             for j, value in enumerate(sub_list):
                 assert validator_return_value[i][j] == value
+
+    def test_integer_list_item(self):
+        allowed_values = [1, 3, 5]
+        int_list_item_validator = integer_list_item('prop_name', allowed_values)
+
+        int_list_item_validator(1)
+        int_list_item_validator(3)
+        int_list_item_validator(5)
+
+        with pytest.raises(ValueError):
+            int_list_item_validator('not_an_integer')
+        with pytest.raises(ValueError):
+            int_list_item_validator(0)
+        with pytest.raises(ValueError):
+            int_list_item_validator(2)
+        with pytest.raises(ValueError):
+            int_list_item_validator(6)


### PR DESCRIPTION
### Issue
#129 


### List of Changes Proposed
Add support for:
    https://www.packer.io/docs/builders/amazon-instance.html#block_duration_minutes
    https://www.packer.io/docs/builders/amazon-ebsvolume.html#block_duration_minutes
    https://www.packer.io/docs/builders/amazon-ebssurrogate.html#block_duration_minutes
    https://www.packer.io/docs/builders/amazon-ebs.html#block_duration_minutes



### Testing Evidence
See unit tests.
