### PR TITLE
buider/HypervVmcx : add temp_path, clone_from_vmcx_path

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -922,7 +922,7 @@ class HypervVmcx(PackerBuilder):
     resource_type = "hyperv-vmcx"
 
     props = {
-        'clone_from_vmxc_path': (str, False),
+        'clone_from_vmcx_path': (str, False),
         'clone_from_vm_name': (str, False),
         'clone_from_snapshot_name': (str, False),
         'clone_all_snapshots': (validator.boolean, False),
@@ -958,13 +958,14 @@ class HypervVmcx(PackerBuilder):
         'skip_export': (validator.boolean, False),
         'switch_name': (str, False),
         'switch_vlan_id': (str, False),
+        'temp_path': (str, False),
         'vlan_id': (str, False),
         'vm_name': (str, False),
     }
 
     def validate(self):
         conds = [
-            'clone_from_vmxc_path',
+            'clone_from_vmcx_path',
             'clone_from_vm_name'
         ]
         validator.exactly_one(self.__class__.__name__, self.properties, conds)

--- a/tests/packerlicious/test_builder_hyperv.py
+++ b/tests/packerlicious/test_builder_hyperv.py
@@ -24,7 +24,7 @@ class TestHypervVmcxBuilder(object):
 
     def test_exactly_one_clone_from_required(self):
         b = builder.HypervVmcx(
-            clone_from_vmxc_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
+            clone_from_vmcx_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
             clone_from_vm_name="ubuntu-12.04.5-server-amd64"
         )
 
@@ -35,7 +35,7 @@ class TestHypervVmcxBuilder(object):
 
     def test_exactly_one_clone_from_specified(self):
         b = builder.HypervVmcx(
-            clone_from_vmxc_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
+            clone_from_vmcx_path="c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
         )
 
         b.to_dict()

--- a/tests/packerlicious/test_builder_hyperv.py
+++ b/tests/packerlicious/test_builder_hyperv.py
@@ -20,7 +20,7 @@ class TestHypervVmcxBuilder(object):
 
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
-        assert 'HypervVmcx: one of the following must be specified: clone_from_vmxc_path, clone_from_vm_name' == str(excinfo.value)
+        assert 'HypervVmcx: one of the following must be specified: clone_from_vmcx_path, clone_from_vm_name' == str(excinfo.value)
 
     def test_exactly_one_clone_from_required(self):
         b = builder.HypervVmcx(
@@ -30,7 +30,7 @@ class TestHypervVmcxBuilder(object):
 
         with pytest.raises(ValueError) as excinfo:
             b.to_dict()
-        assert 'HypervVmcx: only one of the following can be specified: clone_from_vmxc_path, clone_from_vm_name' == str(
+        assert 'HypervVmcx: only one of the following can be specified: clone_from_vmcx_path, clone_from_vm_name' == str(
             excinfo.value)
 
     def test_exactly_one_clone_from_specified(self):


### PR DESCRIPTION

### Issue
fixes #147 


### List of Changes Proposed
Packer had a typo in HypervVmcx attribute clone_from_vmcx_path. Corrected it. Ref: https://www.packer.io/docs/builders/hyperv-vmcx.html#clone_from_vmcx_path
Adding temp_path attribute support to HypervVmcx builder.
Ref: https://www.packer.io/docs/builders/hyperv-vmcx.html#temp_path

