### PR TITLE
Add support for `ssh_clear_authorized_keys`

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -35,6 +35,7 @@ class PackerCommunicator(BasePackerObject):
         'ssh_bastion_port': (validator.integer, False),
         'ssh_bastion_private_key_file': (str, False),
         'ssh_bastion_username': (str, False),
+        'ssh_clear_authorized_keys': (validator.boolean, False),
         'ssh_disable_agent': (validator.boolean, False),
         'ssh_file_transfer_method': (str, False),
         'ssh_handshake_attempts': (validator.integer, False),


### PR DESCRIPTION
Happy Hacktoberfest! 🎃 

### Issue
https://github.com/mayn/packerlicious/issues/156


### List of Changes Proposed
Add support for `ssh_clear_authorized_keys`


### Testing Evidence

```
In [1]: from packerlicious import builder, provisioner, Template

In [2]: template = Template()

In [3]: template.add_builder(
   ...:         builder.AmazonEbs(
   ...:           access_key="...",
   ...:           secret_key="...",
   ...:           region = "us-east-1",
   ...:           source_ami="ami-fce3c696",
   ...:           instance_type="t2.micro",
   ...:           ssh_username="ubuntu",
   ...:           ami_name="packer {{timestamp}}",
   ...:           communicator="ssh",
   ...:           ssh_clear_authorized_keys=True))
Out[3]: <packerlicious.builder.AmazonEbs at 0x10e940ac8>

In [4]: print(template.to_json())
{
  "builders": [
    {
      "access_key": "...",
      "ami_name": "packer {{timestamp}}",
      "communicator": "ssh",
      "instance_type": "t2.micro",
      "region": "us-east-1",
      "secret_key": "...",
      "source_ami": "ami-fce3c696",
      "ssh_clear_authorized_keys": "true",
      "ssh_username": "ubuntu",
      "type": "amazon-ebs"
    }
  ]
}
```

`packer` also validates this template:


```
$ cat test.json
{
  "builders": [
    {
      "access_key": "...",
      "ami_name": "packer {{timestamp}}",
      "communicator": "ssh",
      "instance_type": "t2.micro",
      "region": "us-east-1",
      "secret_key": "...",
      "source_ami": "ami-fce3c696",
      "ssh_clear_authorized_keys": "true",
      "ssh_username": "ubuntu",
      "type": "amazon-ebs"
    }
  ]
}

$ packer version
Packer v1.3.1

$ packer validate test.json
Template validated successfully.

```
