### PR TITLE
[inspec] 'Attrs' should be a single string.

### DIFF
--- a/src/packerlicious/community/provisioner.py
+++ b/src/packerlicious/community/provisioner.py
@@ -26,7 +26,7 @@ class Inspec(PackerProvisioner):
 
     props = {
         'test_path': (str, True),
-        'attrs': ([str], False),
+        'attrs': (str, False),
         'controls': ([str], False),
         'extra_arguments': ([str], False),
         'json_config': (str, False),


### PR DESCRIPTION
As per https://github.com/jrbeilke/packer-provisioner-inspec/pull/10, `attrs` should be a singular string.