### PR TITLE
Add memory, usb, and cpus options to virtualbox iso builder

### DIFF
--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -1472,6 +1472,9 @@ class VirtualboxIso(PackerBuilder):
         'vrdp_bind_address': (str, False),
         'vrdp_port_min': (int, False),
         'vrdp_port_max': (int, False),
+        'memory': (int, 512),
+        'usb': (validator.boolean, False),
+        'cpus': (int, 1),
     }
 
     def validate(self):

--- a/src/packerlicious/builder.py
+++ b/src/packerlicious/builder.py
@@ -1472,9 +1472,9 @@ class VirtualboxIso(PackerBuilder):
         'vrdp_bind_address': (str, False),
         'vrdp_port_min': (int, False),
         'vrdp_port_max': (int, False),
-        'memory': (int, 512),
+        'memory': (int, False),
         'usb': (validator.boolean, False),
-        'cpus': (int, 1),
+        'cpus': (int, False),
     }
 
     def validate(self):


### PR DESCRIPTION
add memory, usb, and cpus options to virtualbox iso

### Issue
<!-- Link to the issue being addressed -->


### List of Changes Proposed
<!-- what is being changed and why? -->


### Testing Evidence
<!-- surely this change was tested, show the evidence -->
