### PR TITLE
Adding ARM community builder support

### DIFF
--- a/src/packerlicious/community/builder.py
+++ b/src/packerlicious/community/builder.py
@@ -1,0 +1,29 @@
+"""
+Copyright 2018 Matthew Aynalem
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from ..builder import PackerBuilder
+
+
+class ArmImage(PackerBuilder):
+    """
+    ARM Builder
+    https://github.com/solo-io/packer-builder-arm-image
+    """
+    resource_type = "arm-image"
+
+    props = {
+        'iso_url': (str, True),
+        'iso_checksum_type': (str, True),
+        'iso_checksum': (str, True),
+        'last_partition_extra_size': (int, False)
+    }

--- a/tests/packerlicious/community/test_builder_arm.py
+++ b/tests/packerlicious/community/test_builder_arm.py
@@ -1,0 +1,13 @@
+import pytest
+
+import packerlicious.community.builder as builder
+
+
+class TestArmImageBuilder(object):
+
+    def test_required_fields_missing(self):
+        b = builder.ArmImage()
+
+        with pytest.raises(ValueError) as excinfo:
+            b.to_dict()
+        assert 'required' in str(excinfo.value)


### PR DESCRIPTION
### List of Changes Proposed
Added support for the [Arm](https://github.com/solo-io/packer-builder-arm-image) Packer builder.


### Testing Evidence
```
$ pytest tests/packerlicious/community/test_builder_arm.py
================================================== test session starts ==================================================
platform linux -- Python 3.6.7, pytest-4.1.1, py-1.7.0, pluggy-0.8.1 -- /home/user/packerlicious/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/user/packerlicious, inifile: setup.cfg
collected 1 item                                                                                                        

tests/packerlicious/community/test_builder_arm.py::TestArmBuilder::test_required_fields_missing PASSED            [100%]

=============================================== 1 passed in 0.01 seconds ================================================```

